### PR TITLE
Tighten detection regexp to reject more non-svg input

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ function isBinary(buf) {
 }
 
 module.exports = function (buf) {
-	return !isBinary(buf) && /<svg[^>]*>/.test(buf);
+	return !isBinary(buf) && /^<svg[^>]*>.*<\/svg>$/.test(buf);
 };

--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ function isBinary(buf) {
 }
 
 module.exports = function (buf) {
-	return !isBinary(buf) && /^<svg[^>]*>.*<\/svg>$/.test(buf);
+	return !isBinary(buf) && /<svg[^>]*>.*<\/svg>$/.test(buf);
 };

--- a/test.js
+++ b/test.js
@@ -9,6 +9,10 @@ it('should detect SVG from Buffer', function () {
 	assert(!isSvg(fs.readFileSync('fixture.jpg')));
 });
 
+it('should permit xml declarations', function() {
+  assert(isSvg('<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg></svg>'));
+});
+
 it('should not match svg tags in the middle of a document', function() {
   assert(!isSvg('this is not svg, but it mentions <svg> tags'));
 });

--- a/test.js
+++ b/test.js
@@ -8,3 +8,19 @@ it('should detect SVG from Buffer', function () {
 	assert(isSvg('<svg width="100" height="100" viewBox="0 0 30 30" version="1.1"></svg>'));
 	assert(!isSvg(fs.readFileSync('fixture.jpg')));
 });
+
+it('should not match svg tags in the middle of a document', function() {
+  assert(!isSvg('this is not svg, but it mentions <svg> tags'));
+});
+
+it('should not match malformed input', function() {
+  assert(!isSvg('<svg> hello I am an svg oops maybe not'));
+});
+
+it('should not think the readme is an SVG', function() {
+  assert(!isSvg(fs.readFileSync('readme.md')));
+});
+
+it('should not think its own code is an SVG', function() {
+  assert(!isSvg(fs.readFileSync('index.js')));
+});


### PR DESCRIPTION
The existing regexp matches any string with an occurrence of an `<svg>` tag anywhere in a document.

By looking for a pair of tags and anchoring to the beginning and end of the buffer we can avoid a lot of false positives, including the README of this module and the module's own source code.

A more robust approach would be to attempt to parse the input as XML and validate it against [the svg schema](http://www.w3.org/TR/2002/WD-SVG11-20020108/SVG.xsd) but presumably this would have severe performance implications for client code.