### PR TITLE
Only allow regex to start with valid SVG tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,5 +15,5 @@ function isBinary(buf) {
 }
 
 module.exports = function (buf) {
-	return !isBinary(buf) && /<svg[^>]*>[^]*<\/svg>\s*$/.test(buf);
+	return !isBinary(buf) && /^\s*(?:<\?xml[^>]*>)?(?:<!doctype svg[^>]*>)?<svg[^>]*>[^]*<\/svg>\s*$/i.test(buf);
 };

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,15 @@ isSvg('<svg xmlns="http://www.w3.org/2000/svg"><path fill="#00CD9F"/></svg>');
 //=> true
 ```
 
+## Edge cases
+
+This module performs a quick-and-dirty check. It's fast, but in certain cases it'll give incorrect results.
+
+- Returns `true` for an SVG-like string that isn't well-formed or valid: `<svg><div></svg>`
+- Returns `false` for an SVG that has a comment after the closing tag: `<svg></svg><!-- hello -->`
+
+If you want to make certain that your SVG is *valid*, try parsing it with [libxmljs](https://github.com/polotek/libxmljs).
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -8,10 +8,16 @@ it('should detect SVG from Buffer', function () {
 	assert(isSvg('<svg width="100" height="100" viewBox="0 0 30 30" version="1.1"></svg>'));
 	assert(isSvg('<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg></svg>'));
 	assert(isSvg('<svg></svg>    '));
+	assert(isSvg('    <svg></svg>'));
 	assert(isSvg('<svg>\n</svg>'));
 	assert(!isSvg(fs.readFileSync('fixture.jpg')));
 	assert(!isSvg('this is not svg, but it mentions <svg> tags'));
 	assert(!isSvg('<svg> hello I am an svg oops maybe not'));
+	assert(!isSvg('<svg></svg> this string starts with an svg'));
+	assert(!isSvg('this string ends with an svg <svg></svg>'));
+	assert(!isSvg('<div><svg></svg>'));
+	assert(!isSvg('<div><svg></svg></div>'));
+	assert(!isSvg('this string contains an svg <svg></svg> in the middle'));
 	assert(!isSvg(fs.readFileSync('readme.md')));
 	assert(!isSvg(fs.readFileSync('index.js')));
 });


### PR DESCRIPTION
This could require a major since it'll break in some places where people expects false positives for some reason.

Still won't allow for comments though.

Fixes #2.