### PR TITLE
Allow newlines after XML prolog and/or DOCTYPE declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,5 @@ function isBinary(buf) {
 }
 
 module.exports = function (buf) {
-	return !isBinary(buf) && /^\s*(?:<\?xml[^>]*>)?(?:<!doctype svg[^>]*>)?<svg[^>]*>[^]*<\/svg>\s*$/i.test(buf.toString().replace(htmlCommentRegex, ''));
+	return !isBinary(buf) && /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*>\s*)?<svg[^>]*>[^]*<\/svg>\s*$/i.test(buf.toString().replace(htmlCommentRegex, ''));
 };

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ test('valid SVGs', t => {
 	t.true(m(fs.readFileSync('fixtures/fixture.svg')));
 	t.true(m('<svg width="100" height="100" viewBox="0 0 30 30" version="1.1"></svg>'));
 	t.true(m('<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg></svg>'));
+	t.true(m('<?xml version="1.0" standalone="no"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg></svg>'));
 	t.true(m('<svg></svg>    '));
 	t.true(m('    <svg></svg>'));
 	t.true(m('<svg>\n</svg>'));


### PR DESCRIPTION
Thank you for this package! This pull request fixes the detection of SVG files that have a newline character (or other whitespace) after the XML prolog and/or DOCTYPE declaration.