### PR TITLE
Allow `<! >` inside document tag to be contained in `[]`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,6 @@ function isBinary(buf) {
 	return false;
 }
 
-const regex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:<![^>]*>)*[^>]*>\s*)?<svg[^>]*>[^]*<\/svg>\s*$/i;
+const regex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:\[?(?:\s*<![^>]*>\s*)*\]?)*[^>]*>\s*)?<svg[^>]*>[^]*<\/svg>\s*$/i;
 
 module.exports = input => !isBinary(input) && regex.test(input.toString().replace(htmlCommentRegex, ''));

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ test('valid SVGs', t => {
 	t.true(m('<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg></svg>'));
 	t.true(m('<?xml version="1.0" standalone="no"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg></svg>'));
 	t.true(m('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">]><svg></svg>'));
+	t.true(m('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/"> ]><svg></svg>'));
 	t.true(m('<svg></svg>    '));
 	t.true(m('    <svg></svg>'));
 	t.true(m('<svg>\n</svg>'));


### PR DESCRIPTION
This patch allow multiple <! > to be contained in square brackets inside ```DOCTYPE```. For example:
[ <! ... > <! ... > ]

Now this thing is allowed:
```xml
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ 
  <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> 
  <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/"> 
]>
```

Fixes #11
  