### PR TITLE
Allow falsy inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,4 +17,4 @@ function isBinary(buf) {
 
 const regex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:<![^>]*>)*[^>]*>\s*)?<svg[^>]*>[^]*<\/svg>\s*$/i;
 
-module.exports = input => !isBinary(input) && regex.test(input.toString().replace(htmlCommentRegex, ''));
+module.exports = input => Boolean(input) && !isBinary(input) && regex.test(input.toString().replace(htmlCommentRegex, ''));

--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ test('invalid SVGs', t => {
 	t.false(m('this string contains an svg <svg></svg> in the middle'));
 	t.false(m(fs.readFileSync('readme.md')));
 	t.false(m(fs.readFileSync('index.js')));
+	t.false(m());
 });
 
 test('supports non-english characters', t => {


### PR DESCRIPTION
Hey! Here is a suggestion, tell me what you think.

`isSvg()` throws because of `undefined.charCodeAt`:

```js
   8:     const charCode = isBuf ? buf[i] : buf.charCodeAt(i);
```

I suggest to solve it by adding `Boolean(input) &&` as first check. (`!!input` is disallowed by the linting rules of this project, that's why I went with `Boolean`.)

That way `isSvg(null)` or `isSvg(undefined)` will simply return false, as `isSvg('')` already does.