### PR TITLE
Fix false-positive when the `<!Entity>` tag contains markup

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,22 +17,12 @@ const isBinary = buffer => {
 
 const cleanEntities = svg => {
 	const entityRegex = /\s*<!Entity\s+\S*\s*(?:"|')[^"]+(?:"|')\s*>/img;
-	const entityMarkupRegex = /(?:"|')[^"]+(?:"|')/im;
 	// Get svg entities
 	const entities = svg.match(entityRegex);
-	// Get their content
+	// Remove them
 	if (entities) {
-		const entitiesContent = [];
 		entities.forEach(entity => {
-			const aux = entity.match(entityMarkupRegex);
-			if (aux) {
-				entitiesContent.push(entity.match(entityMarkupRegex)[0]);
-			}
-		});
-
-		// Remove markup
-		entitiesContent.forEach(content => {
-			svg = svg.replace(content, '""');
+			svg = svg.replace(entity, '""');
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ const isBinary = buffer => {
 const cleanEntities = svg => {
 	const entityRegex = /\s*<!Entity\s+\S*\s*(?:"|')[^"]+(?:"|')\s*>/img;
 	// Remove entities
-	svg = svg.replace(entityRegex, '');
-	return svg;
+	return svg.replace(entityRegex, '');
 };
 
 const regex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:\[?(?:\s*<![^>]*>\s*)*\]?)*[^>]*>\s*)?(?:<svg[^>]*>[^]*<\/svg>|<svg[^/>]*\/\s*>)\s*$/i;

--- a/index.js
+++ b/index.js
@@ -17,15 +17,8 @@ const isBinary = buffer => {
 
 const cleanEntities = svg => {
 	const entityRegex = /\s*<!Entity\s+\S*\s*(?:"|')[^"]+(?:"|')\s*>/img;
-	// Get svg entities
-	const entities = svg.match(entityRegex);
-	// Remove them
-	if (entities) {
-		entities.forEach(entity => {
-			svg = svg.replace(entity, '""');
-		});
-	}
-
+	// Remove entities
+	svg = svg.replace(entityRegex, '');
 	return svg;
 };
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,33 @@ const isBinary = buffer => {
 	return false;
 };
 
+const cleanEntities = svg => {
+	const entityRegex = /\s*<!Entity\s+\S*\s*(?:"|')[^"]+(?:"|')\s*>/img;
+	const entityMarkupRegex = /(?:"|')[^"]+(?:"|')/im;
+	// Get svg entities
+	const entities = svg.match(entityRegex);
+	// Get their content
+	if (entities) {
+		const entitiesContent = [];
+		entities.forEach(entity => {
+			const aux = entity.match(entityMarkupRegex);
+			if (aux) {
+				entitiesContent.push(entity.match(entityMarkupRegex)[0]);
+			}
+		});
+
+		// Remove markup
+		entitiesContent.forEach(content => {
+			svg = svg.replace(content, '""');
+		});
+	}
+
+	return svg;
+};
+
 const regex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:\[?(?:\s*<![^>]*>\s*)*\]?)*[^>]*>\s*)?(?:<svg[^>]*>[^]*<\/svg>|<svg[^/>]*\/\s*>)\s*$/i;
 
-const isSvg = input => Boolean(input) && !isBinary(input) && regex.test(input.toString().replace(htmlCommentRegex, ''));
+const isSvg = input => Boolean(input) && !isBinary(input) && regex.test(cleanEntities(input.toString()).replace(htmlCommentRegex, ''));
 
 module.exports = isSvg;
 // TODO: Remove this for the next major release

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ test('valid SVGs', t => {
 	t.true(isSvg('<?xml version="1.0" standalone="no"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg></svg>'));
 	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">]><svg></svg>'));
 	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/"> ]><svg></svg>'));
+	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> ]><svg></svg>'));
 	t.true(isSvg('<svg></svg>    '));
 	t.true(isSvg('    <svg></svg>'));
 	t.true(isSvg('<svg>\n</svg>'));

--- a/test.js
+++ b/test.js
@@ -51,3 +51,7 @@ test('supports non-english characters', t => {
 
 	</svg>`));
 });
+
+test('support markup inside Entity tags', t => {
+	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> ]><svg></svg>'));
+});

--- a/test.js
+++ b/test.js
@@ -52,5 +52,21 @@ test('supports non-english characters', t => {
 });
 
 test('support markup inside Entity tags', t => {
-	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> ]><svg></svg>'));
+	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> ]><svg width="850px" height="700px" version="1.1" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(16,0,0,16,0,0)">&Smile;</g></svg>'));
+	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">]><svg width="850px" height="700px" version="1.1" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(16,0,0,16,0,0)">&Smile;</g></svg>'));
+	t.true(isSvg(`
+	<?xml version="1.0" encoding="utf-8"?>
+		<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ 
+			<!ENTITY Orange "<g transform='translate(0, 5)'><circle cx='12' cy='12' r='1.5' fill='orange'/><path d='M 10 19 L 15 23 20 19' stroke='orange' stroke-width='2'/></g>"> 
+			<!ENTITY Melon "<g transform='translate(10, 10)'><circle cx='12' cy='12' r='1.5' fill='yellow'/><path d='M 10 19 L 15 23 20 19' stroke='yellow' stroke-width='2'/></g>"> 
+		]>
+	<svg width="850px" height="700px" version="1.1"
+		xmlns="http://www.w3.org/2000/svg">
+		<g transform="matrix(16,0,0,16,0,0)">
+ 			&Melon;
+		 </g>
+		 <g transform="matrix(32,0,0,32,0,0)">
+ 			&Orange;
+ 		</g>
+	</svg>`));
 });

--- a/test.js
+++ b/test.js
@@ -9,7 +9,6 @@ test('valid SVGs', t => {
 	t.true(isSvg('<?xml version="1.0" standalone="no"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg></svg>'));
 	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">]><svg></svg>'));
 	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/"> ]><svg></svg>'));
-	t.true(isSvg('<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [ <!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/"> <!ENTITY Smile " <rect x=\'.5\' y=\'.5\' width=\'29\' height=\'39\' fill=\'black\' stroke=\'red\'/> <g transform=\'translate(0, 5)\'> <circle cx=\'15\' cy=\'15\' r=\'10\' fill=\'yellow\'/><circle cx=\'12\' cy=\'12\' r=\'1.5\' fill=\'black\'/><circle cx=\'17\' cy=\'12\' r=\'1.5\' fill=\'black\'/><path d=\'M 10 19 L 15 23 20 19\' stroke=\'black\' stroke-width=\'2\'/></g>"> ]><svg></svg>'));
 	t.true(isSvg('<svg></svg>    '));
 	t.true(isSvg('    <svg></svg>'));
 	t.true(isSvg('<svg>\n</svg>'));


### PR DESCRIPTION
Fixes #23 
Fixes isSvg returning false for valid svg, whenever they included markup inside an <Entity> tag
It now searches for <!Entity> tags and clears them of markup, before applying the usual regex.
Also added an svg with an appropriate example to the valid svg tests.