### PR TITLE
[Security] Bump fast-xml-parser require from ^4.1.3 to ^4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"string"
 	],
 	"dependencies": {
-		"fast-xml-parser": "^4.1.3"
+		"fast-xml-parser": "^4.2.4"
 	},
 	"devDependencies": {
 		"@types/node": "^18.14.2",


### PR DESCRIPTION
Apparently `fast-xml-parser` has a security vulnerability (https://github.com/advisories/GHSA-6w63-h3fj-q4vw) below version `4.2.4`. Thus, I'm proposing we bump the minimum required version from `4.1.3` to `4.2.4`.