### PR TITLE
before svg check, lowercase all the content

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ export default function isSvg(string) {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
-	string = string.trim();
+	string = string.toLowerCase().trim();
 
 	if (string.length === 0) {
 		return false;


### PR DESCRIPTION
lowercasing the content is needed, otherwise <SvG tag will be valid in some browsers and this function won't be able to detect it.