### PR TITLE
Utilize `@file-type/xml` for XML type determination

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {XMLParser, XMLValidator} from 'fast-xml-parser';
+import {XmlTextDetector} from '@file-type/xml';
 
 export default function isSvg(string) {
 	if (typeof string !== 'string') {
@@ -11,27 +11,7 @@ export default function isSvg(string) {
 		return false;
 	}
 
-	// Has to be `!==` as it can also return an object with error info.
-	if (XMLValidator.validate(string) !== true) {
-		return false;
-	}
-
-	let jsonObject;
-	const parser = new XMLParser();
-
-	try {
-		jsonObject = parser.parse(string);
-	} catch {
-		return false;
-	}
-
-	if (!jsonObject) {
-		return false;
-	}
-
-	if (!Object.keys(jsonObject).some(x => x.toLowerCase() === 'svg')) {
-		return false;
-	}
-
-	return true;
+	const xmlTextDetector = new XmlTextDetector();
+	xmlTextDetector.write(string);
+	return xmlTextDetector.isValid() && xmlTextDetector.fileType?.ext === 'svg';
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"string"
 	],
 	"dependencies": {
-		"fast-xml-parser": "^4.4.1"
+		"@file-type/xml": "^0.4.3"
 	},
 	"devDependencies": {
 		"@types/node": "^22.1.0",


### PR DESCRIPTION
Use [@file-type/xml](https://github.com/Borewit/file-type-xml) for XML type determination.

This has a few advantages:
- Will use namespace, if the XML source file does support namespace
- Is faster on larger SVG files (903 ms processing [Propane_flame_contours-en.svg](https://upload.wikimedia.org/wikipedia/commons/c/c1/Propane_flame_contours-en.svg) versus 1428 ms). If validation would not be required (or disabled) the determination could be brought back to 29 ms.
- Smaller dependency footprint

I was just curious I can could pass the unit tests with [@file-type/xml](https://github.com/Borewit/file-type-xml).